### PR TITLE
Fix using i18next's fallback language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-fluent",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "i18nFormat plugin to use fluent format with i18next",
   "main": "./index.js",
   "jsnext:main": "dist/es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class BundleStore {
   }
 
   createBundle(lng, ns, json) {
-    const ftlStr = js2ftl(json);
+    const ftlStr = json ? js2ftl(json) : "";
     const bundle = new FluentBundle(lng, this.options.fluentBundleOptions);
     const errors = bundle.addMessages(ftl(ftlStr));
 

--- a/test/fuent.spec.js
+++ b/test/fuent.spec.js
@@ -69,7 +69,7 @@ describe("fluent format", () => {
   describe("with i18next", () => {
     before(() => {
       i18next.use(Fluent).init({
-        lng: "en",
+        lng: "en-CA",
         fallbackLng: "en",
         resources: {
           en: {


### PR DESCRIPTION
Fixes an issue where i18next-fluent hard crashes when loading a language that has no resources. This happens a lot when using a language detector, since the browser could be set to a language the app doesn't yet support.

With this change, i18next gracefully falls back to the configured fallbackLng.