### PR TITLE
Return undefined when unable to get bundle in getResource

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ class Fluent {
     let bundle = this.store.getBundle(lng, ns);
     const useKey = key.indexOf('.') > -1 ? key.split('.')[0] : key;
 
-    if (!bundle) return key;
+    if (!bundle) return undefined;
     return bundle.getMessage(useKey);
   }
 


### PR DESCRIPTION
- Returns undefined when there is no bundle so that the language and key don't come back as a valid lookup when resolving the key. (Note: This change is the equivalent to line 381 in i18next.js of the i18next library)

