### PR TITLE
Fixes i18next/i18next-fluent#1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,13 @@ class BundleStore {
     });
 
     this.i18next.on('initialized', () => {
-      this.i18next.languages.forEach(lng => {
+      var lngs = _this.i18next.languages || [];
+      var preload = _this.i18next.options.preload || [];
+      
+      lngs
+        .filter(l => !preload.includes(l))
+        .concat(preload)
+        .forEach(lng => {
         this.i18next.options.ns.forEach(ns => {
           this.createBundleFromI18next(lng, ns);
         });


### PR DESCRIPTION
Use the i18next `preload` option to load languages on top of the ones
detected by i18next after it is initialized. Fixes an issue server-side
where the language detection only runs during a request and not during
the initialization step, resulting in the language loading throwing an
error.

The fix was tested server-side in combination with 18next-node-fs-backend
and i18next-express-middleware. It was also tested client-side in
combination with i18next-fluent-backend and
i18next-browser-languagedetector.